### PR TITLE
Use string interpolation for box-shadow mixin

### DIFF
--- a/stylesheets/partials/_mixins.sass
+++ b/stylesheets/partials/_mixins.sass
@@ -215,7 +215,7 @@
       +background(linear-gradient(left, #d20e1b, #d20e1b 25%, #3156e6 25%, #3156e6 50%, #2aa134 50%, #2aa134 75%, #ecb01b 75%, #ecb01b))
       +border-radius(0.2em 0.2em 0 0)
       border-bottom: 1px solid rgba(#000,.8)
-      +box-shadow(inset 0 0.063em 0 rgba(#fff,.4), inset 0 0 0.063em rgba(#fff,.6), 0 0.063em 0 rgba(#fff,.3))
+      +box-shadow(#{inset 0 0.063em 0 rgba(#fff,.4), inset 0 0 0.063em rgba(#fff,.6), 0 0.063em 0 rgba(#fff,.3)})
       z-index: 0
     & > span:before
       content: "+"


### PR DESCRIPTION
I got the error "Line 218 of _mixins.sass: Mixin box-shadow takes 1 argument but 3 were passed." when trying to use the gem version.
Using string interpolation to pass the variables to the box-shadow mixin fixed it. 
